### PR TITLE
refactor: unify binPath function

### DIFF
--- a/docs/src/extract-settings.mjs
+++ b/docs/src/extract-settings.mjs
@@ -1,8 +1,9 @@
 import fs from "node:fs";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 import packageJson from "../../package.json";
 
-const _dirname = new URL(".", import.meta.url).pathname;
+const _dirname = path.parse(fileURLToPath(import.meta.url)).dir;
 
 const pageContent = `---
 title: Extension Settings

--- a/mise.toml
+++ b/mise.toml
@@ -34,7 +34,7 @@ outputs = ['node_modules/.pnpm/lock.yaml']
 
 [tasks.start-vscode]
 description = 'Starts VSCode with the extension loaded'
-run = 'code --inspect-extensions=5858 --extensionDevelopmentPath=$(pwd)'
+run = 'code --inspect-extensions=5858 --extensionDevelopmentPath={{cwd}}'
 sources = ['src/**', 'package.json', 'syntaxes/**']
 wait_for = ['install']
 
@@ -43,7 +43,7 @@ run = 'mise watch -t start-vscode'
 
 [tasks.start-vscode-inspect-brk]
 description = 'Starts VSCode with the extension loaded. Pauses on the first line of the extension'
-run = 'code --inspect-brk-extensions=5858 --extensionDevelopmentPath=$(pwd)'
+run = 'code --inspect-brk-extensions=5858 --extensionDevelopmentPath={{cwd}}'
 
 [tasks.dev-extension]
 depends = ['install']

--- a/src/miseService.ts
+++ b/src/miseService.ts
@@ -132,6 +132,16 @@ export class MiseService {
 		this.execMiseCommand(command, { setMiseEnv }),
 	);
 
+	async cacheExec({
+		command,
+		setMiseEnv,
+	}: {
+		command: string;
+		setMiseEnv?: boolean;
+	}) {
+		return this.cache.execCmd({ command, setMiseEnv });
+	}
+
 	private slowCache = createCache({
 		ttl: 60,
 		storage: { type: "memory" },
@@ -643,9 +653,9 @@ export class MiseService {
 		});
 		const out = stdout.trim();
 		if (out === "") {
-			return undefined
+			return undefined;
 		}
-		return out
+		return out;
 	}
 
 	async getAllBinsForTool(toolName: string) {
@@ -957,12 +967,12 @@ export class MiseService {
 	}
 	async getSetting(key: string): Promise<string | undefined> {
 		if (!this.getMiseBinaryPath()) {
-			return undefined
+			return undefined;
 		}
 
-		const { stdout } = await this.execMiseCommand(
-			`settings get --quiet --silent ${key}`,
-		);
+		const { stdout } = await this.cacheExec({
+			command: `settings get --quiet --silent ${key}`,
+		});
 		return stdout;
 	}
 
@@ -1100,8 +1110,11 @@ export class MiseService {
 		);
 	}
 
-	async createMiseToolSymlink(binName: string, binPath: string,
-		targetType: 'dir' | 'file' = 'dir') {
+	async createMiseToolSymlink(
+		binName: string,
+		binPath: string,
+		targetType: "dir" | "file" = "dir",
+	) {
 		const toolsPaths = path.join(
 			this.getCurrentWorkspaceFolderPath() ?? "",
 			".vscode",

--- a/src/utils/configureExtensionUtil.ts
+++ b/src/utils/configureExtensionUtil.ts
@@ -1,5 +1,5 @@
-import * as path from "node:path";
 import { existsSync } from "node:fs";
+import * as path from "node:path";
 import * as vscode from "vscode";
 import { ConfigurationTarget } from "vscode";
 import { updateVSCodeSettings } from "../configuration";
@@ -28,12 +28,12 @@ export async function configureSimpleExtension(
 		configKey: string;
 		useShims: boolean;
 		windowsShimOnlyEXE?: boolean;
-		windowsExtOptional?: boolean,
+		windowsExtOptional?: boolean;
 		useSymLinks: boolean;
 		tool: MiseTool;
 		miseConfig: MiseConfig;
 		binName?: string;
-		valueTransformer?: (bin: string) => VSCodeSettingValue | undefined,
+		valueTransformer?: (bin: string) => VSCodeSettingValue | undefined;
 	},
 ) {
 	const bin = await getConfiguredBinPath(miseService, {
@@ -44,20 +44,19 @@ export async function configureSimpleExtension(
 		tool,
 		miseConfig,
 		binName,
-	})
+	});
 
 	if (bin === undefined) {
-		return {}
+		return {};
 	}
+
 	if (valueTransformer !== undefined) {
-		return {
-			[configKey]: valueTransformer(bin),
-		};
-	} else {
-		return {
-			[configKey]: bin,
-		};
+		return { [configKey]: valueTransformer(bin) };
 	}
+
+	return {
+		[configKey]: bin,
+	};
 }
 
 export async function getConfiguredBinPath(
@@ -76,7 +75,7 @@ export async function getConfiguredBinPath(
 		windowsShimOnlyEXE: boolean;
 		// extension in windows, the `.exe` ext is optional
 		// this help extension like `Deno` make no difference to linux/unix  in `settings.json`
-		windowsExtOptional: boolean,
+		windowsExtOptional: boolean;
 
 		useSymLinks: boolean;
 		tool: MiseTool;
@@ -84,23 +83,25 @@ export async function getConfiguredBinPath(
 		binName: string;
 	},
 ): Promise<string | undefined> {
-	var updatedPath = ""
+	let updatedPath = "";
+
 	if (useShims) {
-		var shimPath = path.join(miseConfig.dirs.shims, binName);
+		let shimPath = path.join(miseConfig.dirs.shims, binName);
 		if (isWindows) {
 			const mode = (await miseService.getSetting("windows_shim_mode"))?.trim();
 			if (mode === "file" && windowsShimOnlyEXE) {
-				logger.error(`extension tool ${binName}` + " only support `exe` in windows, " +
-					"change mise setting `windows_shim_mode` to `symlink` or `hardlink`")
-				return undefined
+				logger.error(
+					`extension tool ${binName} only support \`exe\` in windows, change mise setting \`windows_shim_mode\` to \`symlink\` or \`hardlink\``,
+				);
+				return undefined;
 			}
 
-			shimPath = shimPath + (mode === "file" ? ".cmd" : ".exe")
+			shimPath = shimPath + (mode === "file" ? ".cmd" : ".exe");
 		}
 		if (!existsSync(shimPath)) {
-			return undefined
+			return undefined;
 		}
-		updatedPath = shimPath
+		updatedPath = shimPath;
 	} else {
 		// let mise handle path
 		// python:
@@ -109,11 +110,11 @@ export async function getConfiguredBinPath(
 		// ruff:
 		//   windows: `ruff.exe`
 		//   linux: `ruff-x86_64-unknown-linux-musl/ruff`
-		const binPath = await miseService.which(binName)
+		const binPath = await miseService.which(binName);
 		if (binPath === undefined) {
-			return undefined
+			return undefined;
 		}
-		updatedPath = binPath
+		updatedPath = binPath;
 	}
 
 	if (useSymLinks) {
@@ -121,14 +122,20 @@ export async function getConfiguredBinPath(
 		// cannot use `deno`, must `deno.exe`.
 		// shim name maybe `node.cmd`, keep `.cmd` suffix
 		// so keep ext same with target path
-		const ext = path.extname(updatedPath)
-		const symName = isWindows ? `${binName}${ext}` : binName
-		updatedPath = await miseService.createMiseToolSymlink(symName, updatedPath, 'file');
+		const ext = path.extname(updatedPath);
+		const symName = isWindows ? `${binName}${ext}` : binName;
+		updatedPath = await miseService.createMiseToolSymlink(
+			symName,
+			updatedPath,
+			"file",
+		);
 	}
+
 	if (isWindows && windowsExtOptional) {
-		updatedPath = updatedPath.replace(/\.[^/\\.]+$/, "")
+		updatedPath = updatedPath.replace(/\.[^/\\.]+$/, "");
 	}
-	return updatedPath
+
+	return updatedPath;
 }
 
 export async function configureExtension({
@@ -170,15 +177,8 @@ export async function configureExtension({
 
 	const updatedKeys = await updateVSCodeSettings(
 		Object.entries(extConfig)
-			.map(([key, value]) => {
-				if (value !== undefined) {
-					return { key, value };
-				} else {
-					return undefined;
-				}
-			})
-			.filter(x => x !== undefined)
-		,
+			.map(([key, value]) => (value !== undefined ? { key, value } : undefined))
+			.filter((x) => x !== undefined),
 		ConfigurationTarget.Workspace,
 	);
 

--- a/src/utils/fn.ts
+++ b/src/utils/fn.ts
@@ -21,3 +21,15 @@ export const truncateStr = (str: string, maxLen: number) => {
 	}
 	return `${str.slice(0, maxLen)}...`;
 };
+
+export const mergeArrays = (
+	arr: Array<[string, string | undefined]>,
+): Record<string, string> => {
+	const result: Record<string, string> = {};
+	for (const [k, p] of arr) {
+		if (p !== undefined) {
+			result[k] = p;
+		}
+	}
+	return result;
+};

--- a/src/utils/miseDoctorParser.test.ts
+++ b/src/utils/miseDoctorParser.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { type MiseConfig, parseMiseConfig } from "./miseDoctorParser";
+import { type MiseConfig, parseMiseConfigRaw } from "./miseDoctorParser";
 
 describe("mise doctor parser", () => {
 	test("should parse dirs section correctly", () => {
@@ -24,7 +24,7 @@ shell:
 			},
 		};
 
-		const result = parseMiseConfig(input);
+		const result = parseMiseConfigRaw(input);
 		expect(result.dirs).toEqual(expected.dirs);
 	});
 
@@ -36,7 +36,7 @@ shell:
   /bin/zsh`;
 
 		const expected: MiseConfig = { dirs: { shims: "" } };
-		const result = parseMiseConfig(input);
+		const result = parseMiseConfigRaw(input);
 		expect(result.dirs).toEqual(expected.dirs);
 	});
 
@@ -47,7 +47,7 @@ shell:
 
 		const expected: MiseConfig = { dirs: { shims: "" } };
 
-		const result = parseMiseConfig(input);
+		const result = parseMiseConfigRaw(input);
 		expect(result.dirs).toEqual(expected.dirs);
 	});
 
@@ -70,7 +70,7 @@ dirs:
 			},
 		};
 
-		const result = parseMiseConfig(input);
+		const result = parseMiseConfigRaw(input);
 		expect(result.dirs).toEqual(expected.dirs);
 	});
 
@@ -90,7 +90,7 @@ dirs:
 			},
 		};
 
-		const result = parseMiseConfig(input);
+		const result = parseMiseConfigRaw(input);
 		expect(result.dirs).toEqual(expected.dirs);
 	});
 
@@ -124,7 +124,7 @@ config_files:
 			},
 		};
 
-		const result = parseMiseConfig(input);
+		const result = parseMiseConfigRaw(input);
 		expect(result.dirs).toEqual(expected.dirs);
 	});
 
@@ -156,7 +156,7 @@ No warnings found
 			},
 		} satisfies MiseConfig;
 
-		const result = parseMiseConfig(input);
+		const result = parseMiseConfigRaw(input);
 		expect(result.problems).toEqual(expected.problems);
 	});
 });

--- a/src/utils/miseDoctorParser.ts
+++ b/src/utils/miseDoctorParser.ts
@@ -19,7 +19,7 @@ type MiseConfig = {
 	};
 };
 
-function parseMiseConfig(content: string): MiseConfig {
+function parseMiseConfigRaw(content: string): MiseConfig {
 	const result: MiseConfig = { dirs: { shims: "" }, problems: {} };
 	const lines: string[] = content.split("\n");
 
@@ -79,17 +79,19 @@ function parseMiseConfig(content: string): MiseConfig {
 			currentSection = null;
 		}
 	}
-
-	for (const [key, value] of Object.entries(result.dirs)) {
-		if (!value) {
-			continue;
-		}
-
-		result.dirs[key] = expandPath(value);
-	}
-
 	return result;
 }
 
-export { parseMiseConfig };
+function parseMiseConfig(content: string): MiseConfig {
+	const cfg = parseMiseConfigRaw(content);
+	for (const [key, value] of Object.entries(cfg.dirs)) {
+		if (!value) {
+			continue;
+		}
+		cfg.dirs[key] = expandPath(value);
+	}
+	return cfg;
+}
+
+export { parseMiseConfig, parseMiseConfigRaw };
 export type { MiseConfig, MiseDirs };


### PR DESCRIPTION
1. use mise handle real binPath
2. check shim file exist
3. windowsExtension add parameter shimOnlyEXE & extOptional
4. add valueTransformer adapt different extension
5. fix windows symlink create
6. ruff add `ruff.interpreter`
7. go
    1. add `gopls` and make `dlv` `gopls` `go` optional
    2. add some extension notes
8. node support `.cmd` and optional ext
9. fix task & test error windows

fix: https://github.com/hverlin/mise-vscode/issues/104