### PR TITLE
Add support for Java in Red Hat and Salesforce extensions

### DIFF
--- a/docs/src/content/docs/guides/java.mdx
+++ b/docs/src/content/docs/guides/java.mdx
@@ -10,7 +10,7 @@ Here are the steps to set up Java in VS Code with mise:
 
 <Steps>
 1. Install the [mise-vscode extension](https://marketplace.visualstudio.com/items?itemName=hverlin.mise-vscode#overview) (if not already installed)
-1. Install the [Java extension](https://marketplace.visualstudio.com/items?itemName=oracle.oracle-java) for VS Code
+1. Install the [Oracle's Java extension](https://marketplace.visualstudio.com/items?itemName=oracle.oracle-java) or [Language Support for Java by Red Hat](https://marketplace.visualstudio.com/items?itemName=redhat.java) for VS Code
 1. Open a project with a `mise.toml` file (or any other files supported by mise)
 1. The Java SDK will be automatically detected and configured by `mise-vscode`
 </Steps>

--- a/package.json
+++ b/package.json
@@ -141,6 +141,8 @@
 							"golang.go",
 							"oven.bun-vscode",
 							"oracle.oracle-java",
+							"redhat.java",
+							"salesforce.salesforcedx-vscode-apex",
 							"timonwong.shellcheck",
 							"ms-vscode.js-debug",
 							"vscode.php-language-features",

--- a/src/utils/supportedExtensions.ts
+++ b/src/utils/supportedExtensions.ts
@@ -29,6 +29,18 @@ export type ConfigurableExtension = {
 	>;
 };
 
+const generateJavaConfiguration =
+	(keyName: string) => async (config: GenerateConfigProps) => {
+		return {
+			[keyName]: config.useSymLinks
+				? await config.miseService.createMiseToolSymlink(
+						"java",
+						config.tool.install_path,
+					)
+				: config.tool.install_path,
+		};
+	};
+
 export const SUPPORTED_EXTENSIONS: Array<ConfigurableExtension> = [
 	{
 		extensionId: "ms-python.python",
@@ -184,13 +196,19 @@ export const SUPPORTED_EXTENSIONS: Array<ConfigurableExtension> = [
 	{
 		extensionId: "oracle.oracle-java",
 		toolNames: ["java"],
-		generateConfiguration: async ({ miseService, tool, useSymLinks }) => {
-			return {
-				"jdk.jdkhome": useSymLinks
-					? await miseService.createMiseToolSymlink("java", tool.install_path)
-					: tool.install_path,
-			};
-		},
+		generateConfiguration: generateJavaConfiguration("jdk.jdkhome"),
+	},
+	{
+		extensionId: "redhat.java",
+		toolNames: ["java"],
+		generateConfiguration: generateJavaConfiguration("java.jdt.ls.java.home"),
+	},
+	{
+		extensionId: "salesforce.salesforcedx-vscode-apex",
+		toolNames: ["java"],
+		generateConfiguration: generateJavaConfiguration(
+			"salesforcedx-vscode-apex.java.home",
+		),
 	},
 	{
 		extensionId: "timonwong.shellcheck",


### PR DESCRIPTION
Currently, this extension only supports Oracle's Java extension for VS Code. This PR adds support for a few more extensions, namely the Red Hat Java Language Support extension (which uses the `java.jdt.ls.java.home` key as described [here](https://github.com/redhat-developer/vscode-java?tab=readme-ov-file#supported-vs-code-settings)), and the Salesforce Apex VS Code Extension (which uses the `salesforcedx-vscode-apex.java.home` key as described [here](https://developer.salesforce.com/docs/platform/sfvscode-extensions/guide/java-setup.html)). I did some minor refactor as well, since the logic to determine the Java path is the same across all these extensions.