### PR TITLE
feat: add support for Java in Gradle extension

### DIFF
--- a/package.json
+++ b/package.json
@@ -142,6 +142,7 @@
 							"oven.bun-vscode",
 							"oracle.oracle-java",
 							"redhat.java",
+							"vscjava.vscode-gradle",
 							"salesforce.salesforcedx-vscode-apex",
 							"timonwong.shellcheck",
 							"ms-vscode.js-debug",

--- a/src/utils/supportedExtensions.ts
+++ b/src/utils/supportedExtensions.ts
@@ -204,6 +204,13 @@ export const SUPPORTED_EXTENSIONS: Array<ConfigurableExtension> = [
 		generateConfiguration: generateJavaConfiguration("java.jdt.ls.java.home"),
 	},
 	{
+		extensionId: "vscjava.vscode-gradle",
+		toolNames: ["java"],
+		generateConfiguration: generateJavaConfiguration(
+			"java.import.gradle.java.home",
+		),
+	},
+	{
 		extensionId: "salesforce.salesforcedx-vscode-apex",
 		toolNames: ["java"],
 		generateConfiguration: generateJavaConfiguration(


### PR DESCRIPTION
Yet another one for Java support in the Gradle extension, sorry I should've added this directly in my earlier PR 😅

This adds the path to Java to the key `java.import.gradle.java.home`, which is described here: https://github.com/microsoft/vscode-gradle?tab=readme-ov-file#java-specific-settings

I appreciate you merging in the earlier PR so quickly, and your work for this extension in general! 🔥 