### PR TITLE
feat: add support for extension 'signageos.signageos-vscode-sops'

### DIFF
--- a/docs/src/content/docs/reference/Settings.md
+++ b/docs/src/content/docs/reference/Settings.md
@@ -82,6 +82,7 @@ List of extensions that should not be configured automatically.
 - `Dart-Code.dart-code`
 - `dart-code.flutter`
 - `ziglang.vscode-zig`
+- `signageos.signageos-vscode-sops`
 
 ---
 

--- a/docs/src/content/docs/reference/Supported-extensions.md
+++ b/docs/src/content/docs/reference/Supported-extensions.md
@@ -33,6 +33,7 @@ If you want to configure it manually, search for
 | [dart](https://marketplace.visualstudio.com/items?itemName=Dart-Code.dart-code)           | `dart.sdkPath`                                                                                                 | Does not work with shims or symlinks                                                                                        |
 | [flutter](https://marketplace.visualstudio.com/items?itemName=dart-code.flutter)          | `dart.flutterSdkPath`                                                                                          | Does not work with shims or symlinks                                                                                        |
 | [zig](https://marketplace.visualstudio.com/items?itemName=ziglang.vscode-zig)             | `zig.path`, `zig.zls.path` (install [zls](https://mise.jdx.dev/lang/zig.html#zig-language-server) with `mise`) |                                                                                                                             |
+| [sops](https://marketplace.visualstudio.com/items?itemName=signageos.signageos-vscode-sops) | `sops.binPath`                                                                              |                                                                                                                             |
 
 Extensions which have built-in support for `mise`:
 

--- a/package.json
+++ b/package.json
@@ -152,7 +152,8 @@
 							"pgourlain.erlang",
 							"Dart-Code.dart-code",
 							"dart-code.flutter",
-							"ziglang.vscode-zig"
+							"ziglang.vscode-zig",
+							"signageos.signageos-vscode-sops"
 						]
 					},
 					"markdownDescription": "List of extensions that should not be configured automatically."

--- a/src/utils/supportedExtensions.ts
+++ b/src/utils/supportedExtensions.ts
@@ -389,6 +389,25 @@ export const SUPPORTED_EXTENSIONS: Array<ConfigurableExtension> = [
 			});
 		},
 	},
+	{
+		toolNames: ["sops"],
+		extensionId: "signageos.signageos-vscode-sops",
+		generateConfiguration: async ({
+			miseService,
+			tool,
+			miseConfig,
+			useShims,
+			useSymLinks,
+		}) => {
+			return configureSimpleExtension(miseService, {
+				configKey: "sops.binPath",
+				useShims,
+				useSymLinks,
+				tool,
+				miseConfig,
+			});
+		},
+	},
 ];
 
 export const CONFIGURABLE_EXTENSIONS_BY_TOOL_NAME = new Map<


### PR DESCRIPTION
Hello! This PR adds support for the signageos.signageos-vscode-sops extension for SOPS.

Please let me know if anything needs changed or fixed, I did my best to test/lint/etc according to CONTRIBUTING.md.

Thanks for a great extension!