### PR TITLE
Docs of `mise.configureExtensionsUseSymLinks` when `.vscode` is version controlled

### DIFF
--- a/docs/src/content/docs/reference/Settings.md
+++ b/docs/src/content/docs/reference/Settings.md
@@ -129,7 +129,11 @@ Use shims when configuring extensions. When shims are not used, note that you wi
 - **Type:** `boolean`
 - **Default:** `false`
 
-Create symlinks in your `.vscode` folder that links to the `mise` bin. This is useful if you share the `.vscode/settings.json` file with others.
+Create symlinks in your `.vscode` folder that links to the `mise` bin.
+
+This is useful if you share the `.vscode/settings.json` file with others. When the project is version controlled:
+- every user must have the extension installed
+- the directory `.vscode/mise-tools` must be excluded from version control.
 
 ---
 


### PR DESCRIPTION
Refers this comment: https://github.com/hverlin/mise-vscode/issues/120#issuecomment-3359551311