### PR TITLE
feat: add support for extension joselitofilho.ginkgotestexplorer

### DIFF
--- a/docs/src/content/docs/reference/Settings.md
+++ b/docs/src/content/docs/reference/Settings.md
@@ -83,6 +83,7 @@ List of extensions that should not be configured automatically.
 - `dart-code.flutter`
 - `ziglang.vscode-zig`
 - `signageos.signageos-vscode-sops`
+- `joselitofilho.ginkgotestexplorer`
 
 ---
 

--- a/docs/src/content/docs/reference/Supported-extensions.md
+++ b/docs/src/content/docs/reference/Supported-extensions.md
@@ -35,6 +35,7 @@ If you want to configure it manually, search for
 | [flutter](https://marketplace.visualstudio.com/items?itemName=dart-code.flutter)          | `dart.flutterSdkPath`                                                                                          | Does not work with shims or symlinks                                                                                        |
 | [zig](https://marketplace.visualstudio.com/items?itemName=ziglang.vscode-zig)             | `zig.path`, `zig.zls.path` (install [zls](https://mise.jdx.dev/lang/zig.html#zig-language-server) with `mise`) | Does not work with shims or symlinks                                                                                        |
 | [sops](https://marketplace.visualstudio.com/items?itemName=signageos.signageos-vscode-sops) | `sops.binPath`                                                                                               |                                                                                                                             |
+| [ginkgo test explorer](https://marketplace.visualstudio.com/items?itemName=joselitofilho.ginkgotestexplorer) | `ginkgotestexplorer.ginkgoPath`                                                                                               |                                                                                                                             |
 
 Extensions which have built-in support for `mise`:
 

--- a/package.json
+++ b/package.json
@@ -150,7 +150,8 @@
 							"Dart-Code.dart-code",
 							"dart-code.flutter",
 							"ziglang.vscode-zig",
-							"signageos.signageos-vscode-sops"
+							"signageos.signageos-vscode-sops",
+							"joselitofilho.ginkgotestexplorer"
 						]
 					},
 					"markdownDescription": "List of extensions that should not be configured automatically."
@@ -183,7 +184,8 @@
 							"Dart-Code.dart-code",
 							"dart-code.flutter",
 							"ziglang.vscode-zig",
-							"signageos.signageos-vscode-sops"
+							"signageos.signageos-vscode-sops",
+							"joselitofilho.ginkgotestexplorer"
 						]
 					},
 					"markdownDescription": "List of extensions that should be configured automatically. If both include and ignore lists are set, the ignore list takes precedence. If the include list includes 'all' (default), all supported extensions are considered except those in the ignore list."

--- a/src/utils/supportedExtensions.ts
+++ b/src/utils/supportedExtensions.ts
@@ -396,6 +396,19 @@ export const SUPPORTED_EXTENSIONS: Array<ConfigurableExtension> = [
 			});
 		},
 	},
+	{
+		toolNames: ["ginkgo"],
+		extensionId: "joselitofilho.ginkgotestexplorer",
+		generateConfiguration: async ({ miseService, tool, miseConfig }) => {
+			return configureSimpleExtension(miseService, {
+				configKey: "ginkgotestexplorer.ginkgoPath",
+				useShims: false,
+				useSymLinks: false,
+				tool,
+				miseConfig,
+			});
+		},
+	},
 ];
 
 export const CONFIGURABLE_EXTENSIONS_BY_TOOL_NAME = new Map<


### PR DESCRIPTION
Hello! This PR adds support for the Ginkgo Test Explorer extension, which supplements the Go extension for more granular  management of tests.

Please let me know if anything needs changed or fixed, I did my best to test/lint/etc according to CONTRIBUTING.md.

Thanks for a great extension!