### PR TITLE
feat: read all tasks from monorepos

### DIFF
--- a/src/miseService.ts
+++ b/src/miseService.ts
@@ -345,11 +345,20 @@ export class MiseService {
 			return [];
 		}
 
+		let extraArgs = "";
+
+		if (includeHidden) {
+			extraArgs += " --hidden";
+		}
+
+		// The --all flag was added in 2025.10.3
+		if (await this.hasValidMiseVersion([2025, 10, 3])) {
+			extraArgs += " --all";
+		}
+
 		try {
 			const { stdout } = await this.cache.execCmd({
-				command: includeHidden
-					? "tasks ls --all --json --hidden"
-					: "tasks ls --all --json",
+				command: `tasks ls --json ${extraArgs}`,
 			});
 			return JSON.parse(stdout);
 		} catch (error: unknown) {
@@ -856,7 +865,7 @@ export class MiseService {
 		}
 	}
 
-	async hasValidMiseVersion() {
+	async hasValidMiseVersion(minVersion?: readonly [number, number, number]) {
 		if (!this.getMiseBinaryPath()) {
 			return false;
 		}
@@ -866,7 +875,7 @@ export class MiseService {
 			return false;
 		}
 
-		return isVersionGreaterOrEqualThan(version, MIN_MISE_VERSION);
+		return isVersionGreaterOrEqualThan(version, minVersion ?? MIN_MISE_VERSION);
 	}
 
 	async checkNewMiseVersion() {


### PR DESCRIPTION
This adds the `--all` flag to the `tasks ls` call so that tasks can be found in monorepo projects. In my testing, this works without other changes to the code 👍 

~Support for the flag introduced in [Mise 2025.10.3](https://github.com/jdx/mise/releases/tag/v2025.10.3) via [this PR](https://github.com/jdx/mise/pull/6535), but I don't know if you want to support older versions of Mise or not. I can see about adding version checking if that's necessary.~ Yup, you do. Added that in now!

Fixes #141