### PR TITLE
Replace watch icon with eye icon for file watching feature

### DIFF
--- a/package.json
+++ b/package.json
@@ -470,7 +470,7 @@
 			{
 				"command": "mise.watchTask",
 				"title": "Mise: Run Task in Watch Mode",
-				"icon": "$(watch)",
+				"icon": "$(eye-watch)",
 				"enablement": "!isWeb"
 			},
 			{

--- a/src/providers/miseFileTaskCodeLensProvider.ts
+++ b/src/providers/miseFileTaskCodeLensProvider.ts
@@ -48,7 +48,7 @@ export class MiseFileTaskCodeLensProvider implements vscode.CodeLensProvider {
 		);
 		codeLenses.push(
 			new vscode.CodeLens(range, {
-				title: "$(watch) Watch",
+				title: "$(eye-watch) Watch",
 				tooltip: `Watch task ${existingTask.name}`,
 				command: MISE_WATCH_TASK,
 				arguments: [existingTask.name],

--- a/src/providers/miseTomlCodeLensProvider.ts
+++ b/src/providers/miseTomlCodeLensProvider.ts
@@ -29,7 +29,7 @@ function createWatchTaskCodeLens(
 	range: vscode.Range,
 ): vscode.CodeLens {
 	return new vscode.CodeLens(range, {
-		title: "$(watch) Watch",
+		title: "$(eye-watch) Watch",
 		tooltip: `Watch task ${taskName}`,
 		command: MISE_WATCH_TASK,
 		arguments: [taskName],


### PR DESCRIPTION
## Summary
Replaces the clock-based `watch` icon with the `eye` icon for file watching features to improve semantic clarity.

## Changes
- Updated icon from `$(watch)` to [`$(eye-watch)`](https://code.visualstudio.com/api/references/icons-in-labels#icon-listing:~:text=eye%2Dwatch) in [specify location/file]
- No functional changes, UI only

## Screenshots (on macOS)
### Before
<img width="445" height="98" alt="Screenshot 2026-02-06 at 13 33 04" src="https://github.com/user-attachments/assets/809c7e30-0639-4e89-adef-8b89e63be573" />

### After
<img width="509" height="103" alt="Screenshot 2026-02-06 at 13 32 52" src="https://github.com/user-attachments/assets/b3c6fff2-8c9f-421d-aac8-48aa8ec16530" />
