### PR TITLE
FEAT: support for user-defined custom binary and folder linked extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ directly from your editor.
 
 It can automatically
 [configure other extensions](https://hverlin.github.io/mise-vscode/reference/supported-extensions/)
-to use tools provided by `mise` in your current project.
+to use tools provided by `mise` in your current project, including support for custom extensions.
 
 [![mise-vscode screenshot](screenshots/mise-vscode-screenshot.png)](https://hverlin.github.io/mise-vscode/)
 

--- a/docs/src/content/docs/reference/Settings.md
+++ b/docs/src/content/docs/reference/Settings.md
@@ -259,3 +259,41 @@ Auto-detect mise bin path on startup.
 
 ---
 
+##### `mise.customBinaryExtensions`
+- **Type:** `array` (array of `object`)
+- **Default:** `[]`
+
+Custom binary extensions to automatically configure VSCode extensions with mise tool binaries.
+
+Each entry requires:
+- `extensionId`: VSCode extension ID
+- `toolSources`: Array of mise tool registry sources to match
+- `vscodeSetting.key`: VSCode setting key to write
+
+Optional:
+- `binName`: Binary name (defaults to first tool name)
+- `vscodeSetting.subdirs`: Subdirectories to append to the path
+- `supportsShims`: Whether extension supports shims (default: true)
+- `supportsSymlinks`: Whether extension supports symlinks (default: true)
+
+---
+
+##### `mise.customFolderExtensions`
+- **Type:** `array` (array of `object`)
+- **Default:** `[]`
+
+Custom folder extensions to automatically configure VSCode extensions with mise tool folders.
+
+Each entry requires:
+- `extensionId`: VSCode extension ID
+- `toolSources`: Array of mise tool registry sources to match
+- `vscodeSetting.key`: VSCode setting key to write
+- `folderName`: Name for the symlink folder
+
+Optional:
+- `vscodeSetting.subdirs`: Subdirectories to append to the path written to VSCode setting
+- `sourceSubdirs`: Additional subdirs to find the tool source folder
+- `supportsSymlinks`: Whether extension supports symlinks (default: true)
+
+---
+

--- a/docs/src/content/docs/reference/Supported-extensions.md
+++ b/docs/src/content/docs/reference/Supported-extensions.md
@@ -44,6 +44,44 @@ Extensions which have built-in support for `mise`:
 - [Elixir](https://marketplace.visualstudio.com/items?itemName=JakeBecker.elixir-ls)
   will look for `mise` and install the lsp server automatically
 
+## Custom Extensions
+
+You can configure any VSCode extension to use mise tools via settings:
+
+- **`mise.customBinaryExtensions`**: Configure extensions that need a binary path
+- **`mise.customFolderExtensions`**: Configure extensions that need a folder path (e.g., JDK home)
+
+Example for binary mode:
+
+```json
+{
+  "mise.customBinaryExtensions": [
+    {
+      "extensionId": "example.my-extension",
+      "toolSources": ["aqua:mytool"],
+      "vscodeSetting": { "key": "myExtension.toolPath" }
+    }
+  ]
+}
+```
+
+Example for folder mode:
+
+```json
+{
+  "mise.customFolderExtensions": [
+    {
+      "extensionId": "example.java-extension",
+      "toolSources": ["jfox:java", "asdf:openjdk"],
+      "vscodeSetting": { "key": "java.jdkHome" },
+      "folderName": "custom-jdk"
+    }
+  ]
+}
+```
+
+See the Extension Settings for full configuration options.
+
 Extensions that are not supported:
 - [Rust](https://marketplace.visualstudio.com/items?itemName=rust-lang.rust-analyzer) does not offer to update the cargo path automatically. See [this discussion](https://github.com/hverlin/mise-vscode/discussions/70) for workarounds. 
 

--- a/package.json
+++ b/package.json
@@ -367,6 +367,100 @@
           "title": "Auto-detect mise bin path",
           "default": true,
           "markdownDescription": "Auto-detect mise bin path on startup."
+        },
+        "mise.customBinaryExtensions": {
+          "order": 19,
+          "type": "array",
+          "default": [],
+          "markdownDescription": "Custom binary extensions to automatically configure VSCode extensions with mise tool binaries.\n\nEach entry requires:\n- `extensionId`: VSCode extension ID\n- `toolSources`: Array of mise tool registry sources to match\n- `vscodeSetting.key`: VSCode setting key to write\n\nOptional:\n- `binName`: Binary name (defaults to first tool name)\n- `vscodeSetting.subdirs`: Subdirectories to append to the path\n- `supportsShims`: Whether extension supports shims (default: true)\n- `supportsSymlinks`: Whether extension supports symlinks (default: true)",
+          "items": {
+            "type": "object",
+            "required": ["extensionId", "toolSources", "vscodeSetting"],
+            "properties": {
+              "extensionId": {
+                "type": "string",
+                "description": "VSCode extension ID (e.g., 'ms-python.python')"
+              },
+              "toolSources": {
+                "type": "array",
+                "items": { "type": "string" },
+                "description": "Mise tool registry sources to find the tool (e.g., ['python'], ['node', 'aqua:bufbuild/buf'])"
+              },
+              "vscodeSetting": {
+                "type": "object",
+                "required": ["key"],
+                "properties": {
+                  "key": { "type": "string", "description": "VSCode setting key (e.g., 'python.defaultInterpreterPath')" },
+                  "subdirs": {
+                    "type": "array",
+                    "items": { "type": "string" },
+                    "description": "Subdirectories to append to the tool path (e.g., ['bin'] to point to bin folder)"
+                  }
+                }
+              },
+              "binName": {
+                "type": "string",
+                "description": "Binary name to look up (defaults to first tool name)"
+              },
+              "supportsShims": {
+                "type": "boolean",
+                "default": true,
+                "description": "Whether this extension supports mise shims. If false, shims will not be used."
+              },
+              "supportsSymlinks": {
+                "type": "boolean",
+                "default": true,
+                "description": "Whether this extension supports symlinks. If false, symlinks will not be used."
+              }
+            }
+          }
+        },
+        "mise.customFolderExtensions": {
+          "order": 20,
+          "type": "array",
+          "default": [],
+          "markdownDescription": "Custom folder extensions to automatically configure VSCode extensions with mise tool folders.\n\nEach entry requires:\n- `extensionId`: VSCode extension ID\n- `toolSources`: Array of mise tool registry sources to match\n- `vscodeSetting.key`: VSCode setting key to write\n- `folderName`: Name for the symlink folder\n\nOptional:\n- `vscodeSetting.subdirs`: Subdirectories to append to the path written to VSCode setting\n- `sourceSubdirs`: Additional subdirs to find the tool source folder\n- `supportsSymlinks`: Whether extension supports symlinks (default: true)",
+          "items": {
+            "type": "object",
+            "required": ["extensionId", "toolSources", "vscodeSetting", "folderName"],
+            "properties": {
+              "extensionId": {
+                "type": "string",
+                "description": "VSCode extension ID (e.g., 'ms-python.python')"
+              },
+              "toolSources": {
+                "type": "array",
+                "items": { "type": "string" },
+                "description": "Mise tool registry sources to find the tool (e.g., ['python'], ['node', 'aqua:bufbuild/buf'])"
+              },
+              "vscodeSetting": {
+                "type": "object",
+                "required": ["key"],
+                "properties": {
+                  "key": { "type": "string", "description": "VSCode setting key (e.g., 'java.jdkHome')" },
+                  "subdirs": {
+                    "type": "array",
+                    "items": { "type": "string" },
+                    "description": "Subdirectories to append to the path (e.g., ['bin'] to point to bin subfolder)"
+                  }
+                }
+              },
+              "folderName": {
+                "type": "string",
+                "description": "Custom folder name for symlink"
+              },
+              "sourceSubdirs": {
+                "type": "array",
+                "items": { "type": "string" },
+                "description": "Additional subdirs to find the tool source folder (e.g., ['lib'] to use parent/lib as base)"
+              },
+              "supportsSymlinks": {
+                "type": "boolean",
+                "default": true,
+                "description": "Whether extension supports symlinks. If false, direct path will be used."
+              }
+            }
+          }
         }
       }
     },

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -28,6 +28,8 @@ export const CONFIGURATION_FLAGS = {
 	commandTTLCacheSeconds: "commandTTLCacheSeconds",
 	showNotificationIfMissingTools: "showNotificationIfMissingTools",
 	autoDetectMiseBinPath: "autoDetectMiseBinPath",
+	customBinaryExtensions: "customBinaryExtensions",
+	customFolderExtensions: "customFolderExtensions",
 } as const;
 
 const getExtensionConfig = () => {
@@ -188,6 +190,37 @@ export const getCommandTTLCacheSeconds = () => {
 
 export const shouldAutoDetectMiseBinPath = () => {
 	return getConfOrElse(CONFIGURATION_FLAGS.autoDetectMiseBinPath, true);
+};
+
+type VSCodeSettingSubdirs = {
+	key: string;
+	subdirs?: string[];
+};
+
+type CustomBinaryExtensionConfig = {
+	extensionId: string;
+	toolSources: string[];
+	vscodeSetting: VSCodeSettingSubdirs;
+	binName?: string;
+	supportsShims?: boolean;
+	supportsSymlinks?: boolean;
+};
+
+type CustomFolderExtensionConfig = {
+	extensionId: string;
+	toolSources: string[];
+	vscodeSetting: VSCodeSettingSubdirs;
+	folderName: string;
+	sourceSubdirs?: string[];
+	supportsSymlinks?: boolean;
+};
+
+export const getCustomBinaryExtensions = (): CustomBinaryExtensionConfig[] => {
+	return getConfOrElse(CONFIGURATION_FLAGS.customBinaryExtensions, []);
+};
+
+export const getCustomFolderExtensions = (): CustomFolderExtensionConfig[] => {
+	return getConfOrElse(CONFIGURATION_FLAGS.customFolderExtensions, []);
 };
 
 export type VSCodeSettingValue =

--- a/src/providers/toolsProvider.ts
+++ b/src/providers/toolsProvider.ts
@@ -31,7 +31,10 @@ import {
 import { logger } from "../utils/logger";
 import { findToolPosition } from "../utils/miseFileParser";
 import { getWebsiteForTool } from "../utils/miseUtilts";
-import { CONFIGURABLE_EXTENSIONS_BY_TOOL_NAME } from "../utils/supportedExtensions";
+import {
+	CONFIGURABLE_EXTENSIONS_BY_TOOL_NAME,
+	getAllConfigurableExtensions,
+} from "../utils/supportedExtensions";
 
 type TreeItem = ToolsSourceItem | ToolItem;
 
@@ -622,11 +625,20 @@ export function registerToolsCommands(
 			const ignoreList = getIgnoreList();
 			const includeList = getIncludeList();
 
+			const allExtensions = getAllConfigurableExtensions();
+
+			const extByToolName = new Map<string, typeof allExtensions>();
+			for (const ext of allExtensions) {
+				for (const toolName of ext.toolNames) {
+					const existing = extByToolName.get(toolName) ?? [];
+					existing.push(ext);
+					extByToolName.set(toolName, existing);
+				}
+			}
+
 			const tools = await miseService.getCurrentTools();
 			const configurableTools = tools.filter((tool) => {
-				const configurableExtensions = CONFIGURABLE_EXTENSIONS_BY_TOOL_NAME.get(
-					tool.name,
-				);
+				const configurableExtensions = extByToolName.get(tool.name);
 				if (!configurableExtensions?.length) {
 					return false;
 				}
@@ -659,8 +671,7 @@ export function registerToolsCommands(
 			const configurableExtensionsWithTools = configurableTools
 				.filter((tool) => tool.installed)
 				.flatMap((tool) => {
-					const configurableExtensions =
-						CONFIGURABLE_EXTENSIONS_BY_TOOL_NAME.get(tool.name);
+					const configurableExtensions = extByToolName.get(tool.name);
 
 					if (!configurableExtensions?.length) {
 						return [];

--- a/src/utils/supportedExtensions.ts
+++ b/src/utils/supportedExtensions.ts
@@ -1,5 +1,9 @@
 import * as path from "node:path";
 import type { VSCodeSettingValue } from "../configuration";
+import {
+	getCustomBinaryExtensions,
+	getCustomFolderExtensions,
+} from "../configuration";
 import type { MiseService } from "../miseService";
 import {
 	configureSimpleExtension,
@@ -529,6 +533,112 @@ export const SUPPORTED_EXTENSIONS: Array<ConfigurableExtension> = [
 		},
 	},
 ];
+
+function appendSubdirs(basePath: string, subdirs?: string[]): string {
+	if (!subdirs?.length) {
+		return basePath;
+	}
+	return path.join(basePath, ...subdirs);
+}
+
+export function createCustomBinaryExtensionConfig(customConfig: {
+	extensionId: string;
+	toolSources: string[];
+	vscodeSetting: { key: string; subdirs?: string[] };
+	binName?: string;
+	supportsShims?: boolean;
+	supportsSymlinks?: boolean;
+}): ConfigurableExtension {
+	return {
+		extensionId: customConfig.extensionId,
+		toolNames: customConfig.toolSources,
+		generateConfiguration: async ({
+			tool,
+			miseService,
+			miseConfig,
+			useShims,
+			useSymLinks,
+		}) => {
+			const shouldUseShims = customConfig.supportsShims !== false && useShims;
+			const shouldUseSymLinks =
+				customConfig.supportsSymlinks !== false && useSymLinks;
+
+			const resolvedBinName = customConfig.binName || tool.name;
+
+			const result = await configureSimpleExtension(miseService, {
+				configKey: customConfig.vscodeSetting.key,
+				useShims: shouldUseShims,
+				useSymLinks: shouldUseSymLinks,
+				tool,
+				miseConfig,
+				binName: resolvedBinName,
+			});
+
+			if (
+				customConfig.vscodeSetting.subdirs &&
+				result[customConfig.vscodeSetting.key]
+			) {
+				const basePath = result[customConfig.vscodeSetting.key];
+				if (typeof basePath === "string") {
+					result[customConfig.vscodeSetting.key] = appendSubdirs(
+						basePath,
+						customConfig.vscodeSetting.subdirs,
+					);
+				}
+			}
+
+			return result;
+		},
+	};
+}
+
+export function createCustomFolderExtensionConfig(customConfig: {
+	extensionId: string;
+	toolSources: string[];
+	vscodeSetting: { key: string; subdirs?: string[] };
+	folderName: string;
+	sourceSubdirs?: string[];
+	supportsSymlinks?: boolean;
+}): ConfigurableExtension {
+	return {
+		extensionId: customConfig.extensionId,
+		toolNames: customConfig.toolSources,
+		generateConfiguration: async ({ tool, miseService, useSymLinks }) => {
+			const shouldUseSymLinks =
+				customConfig.supportsSymlinks !== false && useSymLinks;
+
+			const sourcePath = appendSubdirs(
+				tool.install_path,
+				customConfig.sourceSubdirs,
+			);
+
+			const folderPath = shouldUseSymLinks
+				? await miseService.createMiseToolSymlink(
+						customConfig.folderName,
+						sourcePath,
+						"dir",
+					)
+				: sourcePath;
+
+			return {
+				[customConfig.vscodeSetting.key]: appendSubdirs(
+					folderPath,
+					customConfig.vscodeSetting.subdirs,
+				),
+			};
+		},
+	};
+}
+
+export function getAllConfigurableExtensions(): ConfigurableExtension[] {
+	const binaryConfigs = getCustomBinaryExtensions();
+	const binaryExtensions = binaryConfigs.map(createCustomBinaryExtensionConfig);
+
+	const folderConfigs = getCustomFolderExtensions();
+	const folderExtensions = folderConfigs.map(createCustomFolderExtensionConfig);
+
+	return [...SUPPORTED_EXTENSIONS, ...binaryExtensions, ...folderExtensions];
+}
 
 export const CONFIGURABLE_EXTENSIONS_BY_TOOL_NAME = new Map<
 	string,


### PR DESCRIPTION
Useful for anyone using custom or private mise tools which wouldn't make sense to permanently add to supported languages

Example usage:
```json
"mise.customBinaryExtensions": [
    {
        "extensionId": "llvm-vs-code-extensions.vscode-clangd",
        "toolSources": [
            "llvm:clang"
        ],
        "binName": "clangd",
        "vscodeSetting": {
            "key": "clangd.path"
        }
    }
],

// If user needs the entire folder available either because the vscode setting needs a folder rather than bin, or for access to other tools
"mise.customFolderExtensions": [
    {
        "extensionId": "llvm-vs-code-extensions.vscode-clangd",
        "toolSources": [
            "llvm:clang"
        ],
        "folderName": "clangd",
        "vscodeSetting": {
            "key": "clangd.path",
            "subdirs": [
                "bin",
                "clangd"
            ],
        }
    }
],
```

Test with https://github.com/Quasiflo/llvm to copy example config above