### PR TITLE
feat: add configureExtensionsIncludeGlobalTools setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,14 @@ The extension will notify you if neither is installed.
 > [!NOTE]
 > The extension includes default settings that you might want to change. See the [configuration guide](https://hverlin.github.io/mise-vscode/tutorials/settinguptheextension/) to customize your set-up.
 > For example, you can choose to enable/disable automatic configuration of other extensions or change the path to the `mise` binary.
-> 
+>
 > You can access the settings by clicking on the mise extension indicator in the status bar.
+
+### Recommended: Disable Global Tools in Auto-Configuration
+
+By default, the extension includes tools from your global mise configuration (`~/.config/mise/config.toml`) when auto-configuring other VS Code extensions. This can pollute your project settings with extensions for tools not in your current project.
+
+**Recommended setting:** Set `mise.configureExtensionsIncludeGlobalTools` to `false` to only use tools from your local `mise.toml` file. This keeps your `.vscode/settings.json` clean and ensures extensions are only configured for tools actually used in your project.
 
 ## ✨ Features
 

--- a/docs/src/content/docs/reference/Settings.md
+++ b/docs/src/content/docs/reference/Settings.md
@@ -147,6 +147,16 @@ This is useful if you share the `.vscode/settings.json` file with others. When t
 
 ---
 
+##### `mise.configureExtensionsIncludeGlobalTools`
+- **Type:** `boolean`
+- **Default:** `false`
+
+When enabled, tools from the global mise configuration (`~/.config/mise/config.toml`) will be included when automatically configuring VS Code extensions.
+
+When disabled (default), only tools from the local project configuration (`mise.toml`) are used. This prevents settings.json from being polluted with extensions for tools that are not part of the current project.
+
+---
+
 ##### `mise.checkForNewMiseVersion`
 - **Type:** `boolean`
 - **Default:** `true`

--- a/docs/src/content/docs/reference/Settings.md
+++ b/docs/src/content/docs/reference/Settings.md
@@ -149,11 +149,11 @@ This is useful if you share the `.vscode/settings.json` file with others. When t
 
 ##### `mise.configureExtensionsIncludeGlobalTools`
 - **Type:** `boolean`
-- **Default:** `false`
+- **Default:** `true`
 
 When enabled, tools from the global mise configuration (`~/.config/mise/config.toml`) will be included when automatically configuring VS Code extensions.
 
-When disabled (default), only tools from the local project configuration (`mise.toml`) are used. This prevents settings.json from being polluted with extensions for tools that are not part of the current project.
+When disabled (recommended), only tools from the local project configuration (`mise.toml`) are used. This prevents settings.json from being polluted with extensions for tools that are not part of the current project.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -274,8 +274,8 @@
           "order": 7.1,
           "type": "boolean",
           "title": "Include global mise tools when auto-configuring extensions",
-          "default": false,
-          "markdownDescription": "When enabled, tools from the global mise configuration (`~/.config/mise/config.toml`) will be included when automatically configuring VS Code extensions.\n\nWhen disabled (default), only tools from the local project configuration (`mise.toml`) are used. This prevents settings.json from being polluted with extensions for tools that are not part of the current project."
+          "default": true,
+          "markdownDescription": "When enabled, tools from the global mise configuration (`~/.config/mise/config.toml`) will be included when automatically configuring VS Code extensions.\n\nWhen disabled (recommended), only tools from the local project configuration (`mise.toml`) are used. This prevents settings.json from being polluted with extensions for tools that are not part of the current project."
         },
         "mise.checkForNewMiseVersion": {
           "order": 8,

--- a/package.json
+++ b/package.json
@@ -270,6 +270,13 @@
           "default": false,
           "markdownDescription": "Create symlinks in your `.vscode` folder that links to the `mise` bin.\n\nThis is useful if you share the `.vscode/settings.json` file with others. When the project is version controlled:\n- every user must have the extension installed\n- the directory `.vscode/mise-tools` must be excluded from version control."
         },
+        "mise.configureExtensionsIncludeGlobalTools": {
+          "order": 7.1,
+          "type": "boolean",
+          "title": "Include global mise tools when auto-configuring extensions",
+          "default": false,
+          "markdownDescription": "When enabled, tools from the global mise configuration (`~/.config/mise/config.toml`) will be included when automatically configuring VS Code extensions.\n\nWhen disabled (default), only tools from the local project configuration (`mise.toml`) are used. This prevents settings.json from being polluted with extensions for tools that are not part of the current project."
+        },
         "mise.checkForNewMiseVersion": {
           "order": 8,
           "type": "boolean",

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -89,7 +89,7 @@ export const shouldUseSymLinks = () => {
 export const shouldIncludeGlobalTools = (): boolean => {
 	return getConfOrElse(
 		CONFIGURATION_FLAGS.configureExtensionsIncludeGlobalTools,
-		false,
+		true,
 	);
 };
 

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -10,6 +10,8 @@ export const CONFIGURATION_FLAGS = {
 	configureExtensionsAutomatically: "configureExtensionsAutomatically",
 	configureExtensionsUseShims: "configureExtensionsUseShims",
 	configureExtensionsUseSymLinks: "configureExtensionsUseSymLinks",
+	configureExtensionsIncludeGlobalTools:
+		"configureExtensionsIncludeGlobalTools",
 	configureExtensionsAutomaticallyIgnoreList:
 		"configureExtensionsAutomaticallyIgnoreList",
 	configureExtensionsAutomaticallyIncludeList:
@@ -81,6 +83,13 @@ export const shouldUseSymLinks = () => {
 	return getConfOrElse(
 		CONFIGURATION_FLAGS.configureExtensionsUseSymLinks,
 		true,
+	);
+};
+
+export const shouldIncludeGlobalTools = (): boolean => {
+	return getConfOrElse(
+		CONFIGURATION_FLAGS.configureExtensionsIncludeGlobalTools,
+		false,
 	);
 };
 

--- a/src/miseService.ts
+++ b/src/miseService.ts
@@ -412,9 +412,13 @@ export class MiseService {
 		}
 	}
 
-	async getCurrentTools(
-		{ useCache }: { useCache?: boolean } = { useCache: true },
-	): Promise<Array<MiseTool>> {
+	async getCurrentTools({
+		useCache = true,
+		local = false,
+	}: {
+		useCache?: boolean;
+		local?: boolean;
+	} = {}): Promise<Array<MiseTool>> {
 		if (!this.getMiseBinaryPath()) {
 			return [];
 		}
@@ -422,7 +426,9 @@ export class MiseService {
 		try {
 			const cacheInstance = useCache ? this.cache : this.dedupeCache;
 			const { stdout } = await cacheInstance.execCmd({
-				command: "ls --current --offline --json",
+				command: local
+					? "ls --local --offline --json"
+					: "ls --current --offline --json",
 			});
 
 			return Object.entries(JSON.parse(stdout)).flatMap(([toolName, tools]) => {

--- a/src/providers/toolsProvider.ts
+++ b/src/providers/toolsProvider.ts
@@ -18,6 +18,7 @@ import {
 	getIgnoreList,
 	getIncludeList,
 	isMiseExtensionEnabled,
+	shouldIncludeGlobalTools,
 	shouldUseShims,
 	shouldUseSymLinks,
 } from "../configuration";
@@ -636,7 +637,9 @@ export function registerToolsCommands(
 				}
 			}
 
-			const tools = await miseService.getCurrentTools();
+			const tools = shouldIncludeGlobalTools()
+				? await miseService.getCurrentTools()
+				: await miseService.getCurrentTools({ local: true });
 			const configurableTools = tools.filter((tool) => {
 				const configurableExtensions = extByToolName.get(tool.name);
 				if (!configurableExtensions?.length) {

--- a/walkthrough/auto-configure.md
+++ b/walkthrough/auto-configure.md
@@ -12,6 +12,9 @@ One of the main features of this extension is the ability to **automatically con
 When enabled, the extension will automatically update your `.vscode/settings.json` file to configure supported VSCode extensions.
 See [the list of supported extensions](https://github.com/hverlin/mise-vscode/wiki/Supported-extensions).
 
+> [!IMPORTANT]
+> **Recommended:** Set `mise.configureExtensionsIncludeGlobalTools` to `false` to only use tools from your local `mise.toml` file. This prevents your project settings from being polluted with extensions for tools not in your current project.
+
 To enable this feature, simply click this button:
 **[Enable Auto-Configuration](command:mise.enableAutoConfiguration)**
 


### PR DESCRIPTION
Adds a new setting `mise.configureExtensionsIncludeGlobalTools` which allows setting whether autoconfiguration for `.vscode/settings.json` configures just workspace used tools or global tools as well. Solves pollution problems. Defaults to local only, as this makes sense for most people.

fixes #120