### PR TITLE
fix: normalize `vX.Y.Z` prefix on both sides of version check

### DIFF
--- a/src/providers/inlineToolDecorator.ts
+++ b/src/providers/inlineToolDecorator.ts
@@ -133,10 +133,15 @@ export async function showToolVersionInline(
 
 				const reqVersion = extractToolVersionFromLine(lineText, raw);
 				if (reqVersion && resolvedVersion) {
+					// Strip a leading `v` from both sides so git-sourced tools
+					// (e.g. `pipx:github/owner/repo` pinned to a tag like
+					// `v0.8.7`) are not flagged as "Not installed" when the
+					// pin and resolved version match modulo the prefix.
 					const normalizedReq = reqVersion.replace(/^v/, "");
+					const normalizedResolved = resolvedVersion.replace(/^v/, "");
 					if (
 						normalizedReq !== "latest" &&
-						!resolvedVersion.startsWith(normalizedReq)
+						!normalizedResolved.startsWith(normalizedReq)
 					) {
 						if (isInline) {
 							continue;


### PR DESCRIPTION
## Summary

The inline "Not installed" decoration in `showToolVersionInline` strips a leading `v` from the *requested* version but compares it against the raw *resolved* version. For tools whose resolved version keeps the `v` prefix, this makes the `startsWith` check fail and the extension reports the tool as not installed even when it is installed and active.

This trips the `pipx:` backend's git-sourced entries. Example:

```toml
# mise.toml
[tools]
"pipx:github/spec-kit" = "v0.8.7"
```

`mise` installs this into `~/.local/share/mise/installs/pipx-github-spec-kit/v0.8.7/` and reports the resolved version verbatim (`v0.8.7`) — so `normalizedReq` is `0.8.7`, `resolvedVersion` is `v0.8.7`, and `"v0.8.7".startsWith("0.8.7")` is `false`. The tool shows as "Not installed" in the editor despite `mise ls --json` reporting `{"installed": true, "active": true}`.

PyPI-style pipx entries (`pipx:black = "26.3.1"`) are unaffected because `mise` doesn't prepend a `v` for those.

## Fix

Strip a leading `v` from **both** sides of the comparison. Symmetric normalization; no behavior change for tools without a `v` prefix.

## Test plan

- [x] `bun x biome check src/providers/inlineToolDecorator.ts` passes
- [x] Manual repro with `"pipx:github/spec-kit" = "v0.8.7"` no longer shows "Not installed" when the tool is installed
- [x] PyPI-style pins like `"pipx:black" = "26.3.1"` continue to render correctly
