### PR TITLE
feat: add "useArray" option to customBinaryExtensions

### DIFF
--- a/docs/src/content/docs/guides/custom-extensions.mdx
+++ b/docs/src/content/docs/guides/custom-extensions.mdx
@@ -30,9 +30,9 @@ Some extensions expect an array of paths instead of a single string. Use `vscode
 {
   "mise.customBinaryExtensions": [
     {
-      "extensionId": "charliermarsh.ruff",
-      "toolSources": ["ruff"],
-      "vscodeSetting": { "key": "ruff.path", "asArray": true }
+      "extensionId": "astral-sh.ty",
+      "toolSources": ["ty"],
+      "vscodeSetting": { "key": "ty.path", "asArray": true }
     }
   ]
 }

--- a/docs/src/content/docs/guides/custom-extensions.mdx
+++ b/docs/src/content/docs/guides/custom-extensions.mdx
@@ -10,7 +10,7 @@ You can configure any VS Code extension to use mise tools via settings:
 - **`mise.customBinaryExtensions`**: Configure extensions that need a binary path
 - **`mise.customFolderExtensions`**: Configure extensions that need a folder path (e.g., JDK home)
 
-Example for binary mode:
+Example for binary mode (string value):
 
 ```json
 {
@@ -19,6 +19,20 @@ Example for binary mode:
       "extensionId": "example.my-extension",
       "toolSources": ["aqua:mytool"],
       "vscodeSetting": { "key": "myExtension.toolPath" }
+    }
+  ]
+}
+```
+
+Some extensions expect an array of paths instead of a single string. Use `vscodeSetting.asArray`:
+
+```json
+{
+  "mise.customBinaryExtensions": [
+    {
+      "extensionId": "charliermarsh.ruff",
+      "toolSources": ["ruff"],
+      "vscodeSetting": { "key": "ruff.path", "asArray": true }
     }
   ]
 }

--- a/docs/src/content/docs/reference/Settings.md
+++ b/docs/src/content/docs/reference/Settings.md
@@ -295,6 +295,7 @@ Each entry requires:
 Optional:
 - `binName`: Binary name (defaults to first tool name)
 - `vscodeSetting.subdirs`: Subdirectories to append to the path
+- `vscodeSetting.asArray`: Whether to wrap the setting value in an array (default: false)
 - `supportsShims`: Whether extension supports shims (default: true)
 - `supportsSymlinks`: Whether extension supports symlinks (default: true)
 

--- a/package.json
+++ b/package.json
@@ -391,7 +391,7 @@
           "order": 19,
           "type": "array",
           "default": [],
-          "markdownDescription": "Custom binary extensions to automatically configure VSCode extensions with mise tool binaries.\n\nEach entry requires:\n- `extensionId`: VSCode extension ID\n- `toolSources`: Array of mise tool registry sources to match\n- `vscodeSetting.key`: VSCode setting key to write\n\nOptional:\n- `binName`: Binary name (defaults to first tool name)\n- `vscodeSetting.subdirs`: Subdirectories to append to the path\n- `supportsShims`: Whether extension supports shims (default: true)\n- `supportsSymlinks`: Whether extension supports symlinks (default: true)",
+          "markdownDescription": "Custom binary extensions to automatically configure VSCode extensions with mise tool binaries.\n\nEach entry requires:\n- `extensionId`: VSCode extension ID\n- `toolSources`: Array of mise tool registry sources to match\n- `vscodeSetting.key`: VSCode setting key to write\n\nOptional:\n- `binName`: Binary name (defaults to first tool name)\n- `vscodeSetting.subdirs`: Subdirectories to append to the path\n- `vscodeSetting.asArray`: Whether to wrap the setting value in an array (default: false)\n- `supportsShims`: Whether extension supports shims (default: true)\n- `supportsSymlinks`: Whether extension supports symlinks (default: true)",
           "items": {
             "type": "object",
             "required": [
@@ -427,6 +427,11 @@
                       "type": "string"
                     },
                     "description": "Subdirectories to append to the tool path (e.g., ['bin'] to point to bin folder)"
+                  },
+                  "asArray": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Whether to wrap the setting value in an array (e.g., ['/path/to/bin'] instead of '/path/to/bin')"
                   }
                 }
               },

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -209,6 +209,7 @@ export const isTaskSymbolProviderEnabled = () => {
 type VSCodeSettingSubdirs = {
 	key: string;
 	subdirs?: string[];
+	asArray?: boolean;
 };
 
 type CustomBinaryExtensionConfig = {

--- a/src/utils/supportedExtensions.ts
+++ b/src/utils/supportedExtensions.ts
@@ -616,7 +616,7 @@ function appendSubdirs(basePath: string, subdirs?: string[]): string {
 export function createCustomBinaryExtensionConfig(customConfig: {
 	extensionId: string;
 	toolSources: string[];
-	vscodeSetting: { key: string; subdirs?: string[] };
+	vscodeSetting: { key: string; subdirs?: string[]; asArray?: boolean };
 	binName?: string;
 	supportsShims?: boolean;
 	supportsSymlinks?: boolean;
@@ -656,6 +656,13 @@ export function createCustomBinaryExtensionConfig(customConfig: {
 						basePath,
 						customConfig.vscodeSetting.subdirs,
 					);
+				}
+			}
+
+			if (customConfig.vscodeSetting.asArray) {
+				const value = result[customConfig.vscodeSetting.key];
+				if (typeof value === "string") {
+					result[customConfig.vscodeSetting.key] = [value];
 				}
 			}
 


### PR DESCRIPTION
Some extensions like `aqua:astral-sh/ty` require the binary's setting ie `ty.path` to be an array with the string contained. This new option allows configs like:

```json
{
  "binName": "ty",
  "extensionId": "astral-sh.ty",
  "supportsShims": true,
  "supportsSymlinks": true,
  "toolSources": [
    "aqua:astral-sh/ty"
  ],
  "vscodeSetting": {
    "asArray": true,  // New feature!
    "key": "ty.path"
  }
}
```

which result in `"ty.path": ["/Users/me/.local/share/mise/shims/ty"],` instead of `"ty.path": "/Users/me/.local/share/mise/shims/ty",`

which is the correct way to configure the setting