### PR TITLE
fix: handle //:name depends without crashing task graph

### DIFF
--- a/src/utils/taskNames.test.ts
+++ b/src/utils/taskNames.test.ts
@@ -448,6 +448,21 @@ describe("dependsPatternMatchesTask", () => {
 			dependsPatternMatchesTask("//projects/frontend:docs:*", "", docsBuild),
 		).toBe(true);
 	});
+
+	// regression: `//:name` (root-config task) crashed micromatch with an empty
+	// path pattern when the target task lived in a non-root config root.
+	it("matches //:name against root tasks only", () => {
+		expect(
+			dependsPatternMatchesTask("//:root-task", "projects/frontend", rootTask),
+		).toBe(true);
+		expect(
+			dependsPatternMatchesTask(
+				"//:root-task",
+				"projects/frontend",
+				frontendBuild,
+			),
+		).toBe(false);
+	});
 });
 
 describe("findTasksMatchingDependsPattern", () => {
@@ -772,6 +787,23 @@ describe("getTaskDependencyEdges", () => {
 			kind: "depends",
 			optional: true,
 		});
+	});
+
+	// regression: a `//:root-task` depends entry crashed graph resolution as
+	// soon as any target task lived in a non-root config root.
+	it("resolves //:name depends without crashing on non-root targets", () => {
+		const tasks = [
+			createTask("//:root-task", "/repo/mise.toml"),
+			{
+				...createTask("//pkg-a:child", "/repo/pkg-a/mise.toml"),
+				depends: ["//:root-task"],
+			},
+			createTask("//pkg-b:other", "/repo/pkg-b/mise.toml"),
+		];
+		const edges = getTaskDependencyEdges(tasks);
+		expect(edges).toEqual([
+			{ from: "//pkg-a:child", to: "//:root-task", kind: "depends" },
+		]);
 	});
 
 	it("does not create self edges", () => {

--- a/src/utils/taskNames.ts
+++ b/src/utils/taskNames.ts
@@ -22,6 +22,11 @@ const MICROMATCH_OPTIONS = {
  * treats `/` as a separator, so both sides are normalized to path-like names.
  */
 function matchesTaskName(name: string, pattern: string) {
+	// picomatch throws on empty patterns; an empty name pattern (e.g. `//path:`)
+	// has no meaningful match against real task names.
+	if (!pattern) {
+		return false;
+	}
 	return micromatch.isMatch(
 		name.replaceAll(":", "/"),
 		pattern.replaceAll(":", "/"),
@@ -461,15 +466,18 @@ export function dependsPatternMatchesTask(
 		}
 		const pathPattern = taskPattern.slice(2, separatorIndex);
 		const namePattern = taskPattern.slice(separatorIndex + 1);
+		// `//:name` targets the root config root only; exact-match handles it, so
+		// skip micromatch (which throws on empty patterns) for non-root targets.
 		const pathMatches =
 			pathPattern === "..."
 				? true
 				: pathPattern === targetConfigRoot ||
-					micromatch.isMatch(
-						targetConfigRoot,
-						pathPattern.replaceAll("...", "**"),
-						MICROMATCH_OPTIONS,
-					);
+					(pathPattern !== "" &&
+						micromatch.isMatch(
+							targetConfigRoot,
+							pathPattern.replaceAll("...", "**"),
+							MICROMATCH_OPTIONS,
+						));
 		return pathMatches && matchesLocalName(namePattern);
 	}
 


### PR DESCRIPTION
`//:name` refers to a task at the monorepo root config root, so the `pathPattern` between `//` and `:` is empty. `dependsPatternMatchesTask` short-circuits when that empty string exactly matches a root target's config root, but for a target in a non-root config root it fell through to `micromatch.isMatch(targetConfigRoot, "", ...)`, which picomatch rejects with `Expected pattern to be a non-empty string`. That path is hit for every non-root task while building the task graph, so a single `//:name` depends entry took the whole graph webview down.

Skip the micromatch call for an empty pathPattern (the exact-match branch already yields the correct answer for root-only targets), and guard `matchesTaskName` against empty patterns defensively so any other edge case that leaks an empty pattern returns `false` instead of throwing.