### PR TITLE
chore: e2e test for python.defaultInterpreterPath in multi-root workspace

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,9 +48,7 @@ jobs:
   e2e-tests:
     runs-on: ubuntu-latest
     name: e2e-tests (${{ matrix.group }})
-    # the sdk-extensions and supported-extensions groups download SDKs and a
-    # dozen extensions; a hung run would otherwise hold a runner for 6 hours
-    timeout-minutes: 60
+    timeout-minutes: 10
 
     strategy:
       fail-fast: false
@@ -61,7 +59,7 @@ jobs:
           - group: core
             labels: default tool-versions bootstrap broken-config command-injection
           - group: workspaces
-            labels: projects custom-extensions task-cache monorepo
+            labels: projects custom-extensions task-cache monorepo multi-root-python
           # multi-root and go share their toolchain store, so the go
           # downloads happen once when they run on the same runner
           - group: go

--- a/.vscode-test.js
+++ b/.vscode-test.js
@@ -5,16 +5,28 @@ const fixturesPath = path.join(__dirname, "src/e2e-tests/fixtures/");
 
 // The multi-root suites write workspace-level settings, which land in the
 // .code-workspace file itself. Those writes are part of what is under test and
-// cannot always be cleaned reliably, so the suite runs against a throwaway
-// gitignored copy of the committed workspace file, refreshed on every run.
-const multiRootWorkspaceFile = path.join(
-	fixturesPath,
+// cannot always be cleaned reliably, so each suite runs against a throwaway
+// gitignored copy of its committed workspace file, refreshed on every run.
+const generatedWorkspaceFile = (fixture, name) => {
+	const generated = path.join(
+		fixturesPath,
+		fixture,
+		`${name}.generated.code-workspace`,
+	);
+	fs.copyFileSync(
+		path.join(fixturesPath, fixture, `${name}.code-workspace`),
+		generated,
+	);
+	return generated;
+};
+
+const multiRootWorkspaceFile = generatedWorkspaceFile(
 	"multi-root-workspace",
-	"multi-root.generated.code-workspace",
+	"multi-root",
 );
-fs.copyFileSync(
-	path.join(fixturesPath, "multi-root-workspace", "multi-root.code-workspace"),
-	multiRootWorkspaceFile,
+const multiRootPythonWorkspaceFile = generatedWorkspaceFile(
+	"multi-root-python-workspace",
+	"multi-root-python",
 );
 
 // The Pkl extension is not published on the marketplace: Apple ships it as a
@@ -335,6 +347,42 @@ module.exports = defineConfig([
 			require: ["tsx/cjs"],
 			// the go suite installs two toolchains
 			timeout: 600_000,
+		},
+	},
+	{
+		label: "multi-root-python",
+		files: "src/e2e-tests/multi-root-python/*.e2e.ts",
+		// a multi-root workspace where a single folder is a python project
+		workspaceFolder: multiRootPythonWorkspaceFile,
+		env: {
+			MISE_CEILING_PATHS: fixturesPath,
+			MISE_LOCKED: "0",
+			MISE_TRUSTED_CONFIG_PATHS: fixturesPath,
+			// Keep the machine's real global config out of the tests, and keep the
+			// python installed by the suite out of the machine's mise data dir.
+			MISE_GLOBAL_CONFIG_FILE: path.join(
+				fixturesPath,
+				"multi-root-python-workspace",
+				"global-config.toml",
+			),
+			MISE_DATA_DIR: path.join(
+				fixturesPath,
+				"multi-root-python-workspace",
+				".mise-data",
+			),
+			MISE_CACHE_DIR: path.join(
+				fixturesPath,
+				"multi-root-python-workspace",
+				".mise-cache",
+			),
+		},
+		// ms-python.python is the extension under test: its interpreter path is
+		// relative to the folder it is written for
+		installExtensions: ["ms-python.python"],
+		mocha: {
+			require: ["tsx/cjs"],
+			// installs a python on a cold cache
+			timeout: 300_000,
 		},
 	},
 	{

--- a/src/e2e-tests/fixtures/multi-root-python-workspace/.gitignore
+++ b/src/e2e-tests/fixtures/multi-root-python-workspace/.gitignore
@@ -1,0 +1,9 @@
+# Written at runtime by the multi-root python e2e suite
+.mise-data/
+.mise-cache/
+# throwaway copy of multi-root-python.code-workspace the suite runs against
+*.generated.code-workspace
+# folder-scoped settings written by per-folder extension configuration
+.vscode/
+# venv mise creates in python-app
+.venv/

--- a/src/e2e-tests/fixtures/multi-root-python-workspace/global-config.toml
+++ b/src/e2e-tests/fixtures/multi-root-python-workspace/global-config.toml
@@ -1,0 +1,3 @@
+# Stands in for the machine global config: the python of the workspace has to
+# be the one its folder declares, never one the machine running the suite has.
+[tools]

--- a/src/e2e-tests/fixtures/multi-root-python-workspace/multi-root-python.code-workspace
+++ b/src/e2e-tests/fixtures/multi-root-python-workspace/multi-root-python.code-workspace
@@ -1,0 +1,16 @@
+{
+	"folders": [
+		{
+			"path": "other-app"
+		},
+		{
+			"path": "python-app"
+		},
+		{
+			"path": "no-mise"
+		}
+	],
+	"settings": {
+		"mise.configureExtensionsAutomatically": false
+	}
+}

--- a/src/e2e-tests/fixtures/multi-root-python-workspace/other-app/mise.toml
+++ b/src/e2e-tests/fixtures/multi-root-python-workspace/other-app/mise.toml
@@ -1,0 +1,10 @@
+# A mise project that is not a python project: it has no venv, so an
+# interpreter path written for another folder would point it at a directory
+# that does not exist. It is the first folder of the workspace, the one the
+# extension works on until another is selected.
+[env]
+WHICH_FOLDER = "other-app"
+
+[tasks.other-app-task]
+description = "Task of the folder without python"
+run = "echo 'other-app'"

--- a/src/e2e-tests/fixtures/multi-root-python-workspace/python-app/mise.toml
+++ b/src/e2e-tests/fixtures/multi-root-python-workspace/python-app/mise.toml
@@ -1,0 +1,8 @@
+# The only python project of the window. mise activates a venv for it, so the
+# interpreter path the extension writes is relative to this folder and belongs
+# to its settings alone (https://github.com/hverlin/mise-vscode/issues/152).
+[tools]
+python = "3.14.7"
+
+[env]
+_.python.venv = { path = ".venv", create = true }

--- a/src/e2e-tests/multi-root-python/multi-root-python.e2e.ts
+++ b/src/e2e-tests/multi-root-python/multi-root-python.e2e.ts
@@ -1,0 +1,203 @@
+import * as assert from "node:assert";
+import { execFile } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
+import * as path from "node:path";
+import { promisify } from "node:util";
+import * as vscode from "vscode";
+import {
+	MISE_CONFIGURE_ALL_SDK_PATHS,
+	MISE_SELECT_WORKSPACE_FOLDER,
+} from "../../commands";
+
+const execFileAsync = promisify(execFile);
+
+const INTERPRETER_PATH = "python.defaultInterpreterPath";
+// biome-ignore lint/suspicious/noTemplateCurlyInString: the vscode variable
+const WORKSPACE_FOLDER_VARIABLE = "${workspaceFolder}";
+
+/**
+ * The python interpreter path in a multi-root workspace
+ * (https://github.com/hverlin/mise-vscode/issues/152).
+ *
+ * The fixture reproduces the layout of the report: one folder is a python
+ * project, the others are not, and one of them does not even use mise.
+ *
+ *   other-app/   a mise project without python, the default workspace folder
+ *   python-app/  the only python project, mise activates a venv for it
+ *   no-mise/     no mise config at all
+ *
+ * mise activates a venv for `python-app`, so the interpreter path the
+ * extension writes is relative to the folder, `${workspaceFolder}/.venv`.
+ * Written workspace-wide, that path resolves against every folder of the
+ * window, and the python extension then reports a missing interpreter in each
+ * folder that has no venv, which is what the issue describes. It belongs to
+ * the settings of the folder declaring python, and to no other folder.
+ */
+suite("Multi-root Python Interpreter Test Suite", function () {
+	// installs a python on a cold cache
+	this.timeout(300_000);
+
+	const pythonFolder = "python-app";
+	const folderNames = ["other-app", "python-app", "no-mise"] as const;
+
+	const folderUri = (name: string) => {
+		const workspaceFile = vscode.workspace.workspaceFile;
+		assert.ok(workspaceFile, "The fixture should open a .code-workspace file");
+		const expected = path.join(path.dirname(workspaceFile.fsPath), name);
+
+		const folder = vscode.workspace.workspaceFolders?.find(
+			(f) => f.uri.fsPath === expected,
+		);
+		assert.ok(folder, `Workspace folder ${name} should exist`);
+		return folder.uri;
+	};
+
+	const selectFolder = (name: string) =>
+		vscode.commands.executeCommand(
+			MISE_SELECT_WORKSPACE_FOLDER,
+			vscode.Uri.file(folderUri(name).fsPath),
+		);
+
+	const inspectInterpreterPath = (name: string) =>
+		vscode.workspace
+			.getConfiguration(undefined, folderUri(name))
+			.inspect<string>(INTERPRETER_PATH);
+
+	/** The interpreter path with `${workspaceFolder}` resolved against `name` */
+	const resolvedInterpreterPath = (name: string, value: string) =>
+		value.replace(WORKSPACE_FOLDER_VARIABLE, folderUri(name).fsPath);
+
+	const clearInterpreterPath = async () => {
+		await vscode.workspace
+			.getConfiguration()
+			.update(
+				INTERPRETER_PATH,
+				undefined,
+				vscode.ConfigurationTarget.Workspace,
+			);
+
+		for (const folder of vscode.workspace.workspaceFolders ?? []) {
+			await vscode.workspace
+				.getConfiguration(undefined, folder.uri)
+				.update(
+					INTERPRETER_PATH,
+					undefined,
+					vscode.ConfigurationTarget.WorkspaceFolder,
+				)
+				// a clear of a folder value vscode refuses is a no-op
+				.then(undefined, () => {});
+		}
+	};
+
+	suiteSetup(async () => {
+		assert.ok(
+			vscode.extensions.getExtension("ms-python.python"),
+			"The python extension has to be installed for mise to configure it",
+		);
+		assert.deepEqual(
+			vscode.workspace.workspaceFolders?.map((folder) => folder.name),
+			[...folderNames],
+		);
+
+		const pythonFolderPath = folderUri(pythonFolder).fsPath;
+		// the mise environment of the suite comes from the extension host
+		await execFileAsync("mise", ["install"], {
+			cwd: pythonFolderPath,
+			maxBuffer: 32 * 1024 * 1024,
+		});
+		// mise creates the venv the first time the environment is evaluated,
+		// once the python it needs is installed
+		await execFileAsync("mise", ["env", "--json"], { cwd: pythonFolderPath });
+		assert.ok(
+			existsSync(path.join(pythonFolderPath, ".venv")),
+			`mise should have created the venv of ${pythonFolder}`,
+		);
+	});
+
+	suiteTeardown(async () => {
+		await clearInterpreterPath();
+		await selectFolder("other-app");
+	});
+
+	setup(async () => {
+		await clearInterpreterPath();
+		// the folder declaring python is not the selected one
+		await selectFolder("other-app");
+		await vscode.commands.executeCommand(MISE_CONFIGURE_ALL_SDK_PATHS);
+	});
+
+	test("writes the interpreter path to the folder that declares python", () => {
+		const value = inspectInterpreterPath(pythonFolder)?.workspaceFolderValue;
+		assert.ok(
+			value,
+			`${INTERPRETER_PATH} should be configured for ${pythonFolder}`,
+		);
+		assert.ok(
+			value.startsWith(WORKSPACE_FOLDER_VARIABLE),
+			`The venv path should be relative to its folder, got ${value}`,
+		);
+		assert.ok(
+			existsSync(resolvedInterpreterPath(pythonFolder, value)),
+			`${INTERPRETER_PATH} should point at the venv of ${pythonFolder}, got ${value}`,
+		);
+	});
+
+	test("never writes the interpreter path workspace-wide", () => {
+		assert.equal(
+			inspectInterpreterPath(pythonFolder)?.workspaceValue,
+			undefined,
+			"A folder-relative interpreter path applies to one folder only",
+		);
+
+		const workspaceFile = vscode.workspace.workspaceFile;
+		assert.ok(workspaceFile);
+		assert.ok(
+			!readFileSync(workspaceFile.fsPath, "utf8").includes(INTERPRETER_PATH),
+			"The .code-workspace file should be left alone",
+		);
+	});
+
+	test("leaves the folders without python alone", () => {
+		for (const folder of folderNames.filter((name) => name !== pythonFolder)) {
+			const inspection = inspectInterpreterPath(folder);
+			assert.equal(
+				inspection?.workspaceFolderValue,
+				undefined,
+				`${folder} has no python: nothing should be written for it`,
+			);
+			assert.equal(
+				inspection?.workspaceValue,
+				undefined,
+				`${folder} should not inherit the interpreter of another folder`,
+			);
+			assert.equal(
+				vscode.workspace
+					.getConfiguration(undefined, folderUri(folder))
+					.get<string>(INTERPRETER_PATH),
+				inspection?.defaultValue,
+				`${folder} should keep the default interpreter of the python extension`,
+			);
+		}
+	});
+
+	test("keeps the interpreter path folder-scoped when its folder is the selected one", async () => {
+		await selectFolder(pythonFolder);
+		await vscode.commands.executeCommand(MISE_CONFIGURE_ALL_SDK_PATHS);
+
+		const inspection = inspectInterpreterPath(pythonFolder);
+		assert.ok(
+			inspection?.workspaceFolderValue,
+			`${INTERPRETER_PATH} should still be configured for ${pythonFolder}`,
+		);
+		assert.equal(
+			inspection?.workspaceValue,
+			undefined,
+			"Selecting the folder should not spread its interpreter to the window",
+		);
+		assert.equal(
+			inspectInterpreterPath("other-app")?.workspaceFolderValue,
+			undefined,
+			"other-app has no python, whichever folder is selected",
+		);
+	});
+});


### PR DESCRIPTION
close #281 