### PR TITLE
feat: Add setting to suppress custom extension config warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -599,6 +599,13 @@
               }
             }
           }
+        },
+        "mise.showCustomExtensionConfigWarnings": {
+          "order": 21,
+          "type": "boolean",
+          "title": "Show custom extension config warnings",
+          "default": true,
+          "markdownDescription": "Show a warning when a custom extension config's `toolSources` do not match any current tools. Disable this if you keep custom extension configs across multiple projects, even if not all projects use those tools."
         }
       }
     },

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -40,6 +40,7 @@ export const CONFIGURATION_FLAGS = {
 	customFolderExtensions: "customFolderExtensions",
 	enableTaskSymbolProvider: "enableTaskSymbolProvider",
 	skipWorkspaceBinaryApproval: "skipWorkspaceBinaryApproval",
+	showCustomExtensionConfigWarnings: "showCustomExtensionConfigWarnings",
 } as const;
 
 const getExtensionConfig = () => {
@@ -299,6 +300,13 @@ export const isTaskSymbolProviderEnabled = () => {
 
 export const shouldResolveMonorepoProjectConfigs = () => {
 	return getConfOrElse(CONFIGURATION_FLAGS.resolveMonorepoProjectConfigs, true);
+};
+
+export const shouldShowCustomExtensionConfigWarnings = (): boolean => {
+	return getConfOrElse(
+		CONFIGURATION_FLAGS.showCustomExtensionConfigWarnings,
+		true,
+	);
 };
 
 type VSCodeSettingSubdirs = {

--- a/src/providers/toolsProvider.ts
+++ b/src/providers/toolsProvider.ts
@@ -19,6 +19,7 @@ import {
 	getIncludeList,
 	isMiseExtensionEnabled,
 	shouldIncludeGlobalTools,
+	shouldShowCustomExtensionConfigWarnings,
 	shouldUseShims,
 	shouldUseSymLinks,
 } from "../configuration";
@@ -769,20 +770,22 @@ export function registerToolsCommands(
 				);
 			}
 
-			const matchedCustomExtensions = new Set<ConfigurableExtension>();
-			for (const tool of allTools) {
-				for (const ext of forToolName(tool.name)) {
-					if (ext.isCustom) {
-						matchedCustomExtensions.add(ext);
+			if (shouldShowCustomExtensionConfigWarnings()) {
+				const matchedCustomExtensions = new Set<ConfigurableExtension>();
+				for (const tool of allTools) {
+					for (const ext of forToolName(tool.name)) {
+						if (ext.isCustom) {
+							matchedCustomExtensions.add(ext);
+						}
 					}
 				}
-			}
 
-			for (const ext of allExtensions) {
-				if (ext.isCustom && !matchedCustomExtensions.has(ext)) {
-					logger.warn(
-						`Custom extension config for ${ext.extensionId}: no current tool matches toolSources [${ext.toolNames.join(", ")}]. toolSources are matched against the tool names from \`mise ls\` and their registry equivalents.`,
-					);
+				for (const ext of allExtensions) {
+					if (ext.isCustom && !matchedCustomExtensions.has(ext)) {
+						logger.warn(
+							`Custom extension config for ${ext.extensionId}: no current tool matches toolSources [${ext.toolNames.join(", ")}]. toolSources are matched against the tool names from \`mise ls\` and their registry equivalents.`,
+						);
+					}
 				}
 			}
 


### PR DESCRIPTION
Adds `mise.showCustomExtensionConfigWarnings` (default: true) to allow users to suppress warnings when a custom extension config's toolSources don't match any current tools.

Useful for users who keep custom extension configs in global/user settings that apply across multiple projects, even when not all projects use those tools.